### PR TITLE
Documentation: Add dependency "jq" to be installed manually.

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -19,6 +19,8 @@ to communicate with SingleFile.
 
 - Install [Node.js](https://nodejs.org)
 
+- Install [jq](https://stedolan.github.io/jq/), the JSON processor
+
 - Download the
   [SingleFile Companion project](https://github.com/gildas-lormeau/single-file-companion/archive/master.zip)
   zip file and unzip it somewhere on your disk.


### PR DESCRIPTION
Hello,

Just found out, that for the installation script to work, one needs to have _jq_ installed.
It might be appropriate to add that to the docs.

Thanks for this app!
hoschi